### PR TITLE
[semver:major] Add additional parameters to upload and delete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             echo "$BASH_ENV" > ./local-file.txt
       - dropbox-orb/upload:
           uploadpath: /uploaded-file.txt
+          mode: overwrite
           filepath: ./local-file.txt
       - dropbox-orb/download:
           downloadpath: /uploaded-file.txt

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This Orb allows for interaction with the [Dropbox HTTP API](https://www.dropbox.com/developers/documentation/http/documentation).
 
+`DROPBOX_TOKEN` environment variable is required to be set to the Generated access token for the application.
+
 ## Resources
 
 [CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/rascaltwo/dropbox-orb) - The official registry page of this orb for all versions, executors, commands, and jobs described.

--- a/src/commands/delete.yml
+++ b/src/commands/delete.yml
@@ -1,9 +1,17 @@
-description: Delete a file from Dropbox
+description: Delete a file or folder from Dropbox
 
 parameters:
   deletepath:
     type: string
-    description: "Path of file to delete"
+    description: Path in the user's Dropbox to delete
+  permanent:
+    type: boolean
+    default: false
+    description: "If to permanently delete the target or not"
+  parent_rev:
+    type: string
+    default: ""
+    description: Perform delete if given "rev" matches the existing file's latest "rev". This field does not support deleting a folder.
 
 steps:
   - run:
@@ -11,5 +19,7 @@ steps:
   - run:
       environment:
         DELETE_PATH: <<parameters.deletepath>>
-      name: Delete File
+        PERMANENT: <<parameters.permanent>>
+        PARENT_REV: <<parameters.parent_rev>>
+      name: Delete File/Folder
       command: <<include(scripts/delete.sh)>>

--- a/src/commands/download.yml
+++ b/src/commands/download.yml
@@ -3,10 +3,10 @@ description: Download a file from Dropbox
 parameters:
   downloadpath:
     type: string
-    description: "Where to download file from"
+    description: The path of the file to download
   filepath:
     type: string
-    description: "Where to download file to"
+    description: Where to download file to
 
 steps:
   - run:

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -7,6 +7,27 @@ parameters:
   uploadpath:
     type: string
     description: Path in the user's Dropbox to save the file
+  mode:
+    type: enum
+    enum: ["add", "overwrite", "update"]
+    default: "add"
+    description: Selects what to do if the file already exists
+  autorename:
+    type: boolean
+    default: false
+    description: If there's a conflict, as determined by mode, have the Dropbox server try to autorename the file to avoid conflict
+  client_modified:
+    type: string
+    default: ""
+    description: The value to store as the client_modified timestamp
+  mute:
+    type: boolean
+    default: false
+    description: If true, this tells the clients that this modification shouldn't result in a user notification
+  strict_conflict:
+    type: boolean
+    default: false
+    description: Be more strict about how each WriteMode detects conflict, also force a conflict even when the target path refers to a file with identical contents
 
 steps:
   - run:
@@ -15,5 +36,10 @@ steps:
       environment:
         FILE_PATH: <<parameters.filepath>>
         UPLOAD_PATH: <<parameters.uploadpath>>
+        MODE: <<parameters.mode>>
+        AUTORENAME: <<parameters.autorename>>
+        CLIENT_MODIFIED: <<parameters.client_modified>>
+        MUTE: <<parameters.mute>>
+        STRICT_CONFLICT: <<parameters.strict_conflict>>
       name: Upload File
       command: <<include(scripts/upload.sh)>>

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -6,7 +6,7 @@ parameters:
     description: "Path of file to upload"
   uploadpath:
     type: string
-    description: "Where to upload file"
+    description: Path in the user's Dropbox to save the file
 
 steps:
   - run:

--- a/src/scripts/delete.sh
+++ b/src/scripts/delete.sh
@@ -1,4 +1,5 @@
 Delete() {
+		# Set url path and prefix based on if the deletion is permanent
 		prefix="";
 		if [[ "${PERMANENT}" = "1" ]]; then
 			urlPath="permanently_delete";
@@ -7,6 +8,7 @@ Delete() {
 			urlPath="delete_v2"
 		fi;
 
+		# Only include parent_rev if it's not blank
 		parentRev="";
 		if [ -n "${PARENT_REV}" ]; then
 			parentRev=", \"parent_rev\": \"${PARENT_REV}\"";

--- a/src/scripts/delete.sh
+++ b/src/scripts/delete.sh
@@ -1,9 +1,22 @@
 Delete() {
-		echo "Deleting '${DELETE_PATH}'..."
-		verboseCurl true -X POST https://api.dropboxapi.com/2/files/delete_v2 \
+		prefix="";
+		if [[ "${PERMANENT}" = "1" ]]; then
+			urlPath="permanently_delete";
+			prefix="Permanently "
+		else
+			urlPath="delete_v2"
+		fi;
+
+		parentRev="";
+		if [ -n "${PARENT_REV}" ]; then
+			parentRev=", \"parent_rev\": \"${PARENT_REV}\"";
+		fi;
+
+		echo "${prefix}Deleting '${DELETE_PATH}'..."
+		verboseCurl true -X POST https://api.dropboxapi.com/2/files/${urlPath} \
 			--header "Authorization: Bearer ${DROPBOX_TOKEN}" \
 			--header "Content-Type: application/json" \
-			--data "{\"path\": \"${DELETE_PATH}\"}"
+			--data "{\"path\": \"${DELETE_PATH}\"${parentRev}}"
 }
 
 # Will not run if sourced for bats-core tests.

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -1,8 +1,18 @@
 Upload() {
 		echo "Uploading '${FILE_PATH}' to '${UPLOAD_PATH}'..."
+
+		clientModified="";
+		if [ -n "${CLIENT_MODIFIED}" ]; then
+			clientModified=", \"client_modified\": \"${CLIENT_MODIFIED}\"";
+		fi;
+
+		[[ "${AUTORENAME}" = "1" ]] && AUTORENAME="true" || AUTORENAME="false"
+		[[ "${MUTE}" = "1" ]] && MUTE="true" || MUTE="false"
+		[[ "${STRICT_CONFLICT}" = "1" ]] && STRICT_CONFLICT="true" || STRICT_CONFLICT="false"
+
 		verboseCurl true -X POST https://content.dropboxapi.com/2/files/upload \
 			--header "Authorization: Bearer ${DROPBOX_TOKEN}" \
-			--header "Dropbox-API-Arg: {\"path\": \"${UPLOAD_PATH}\", \"mode\": \"overwrite\"}" \
+			--header "Dropbox-API-Arg: {\"path\": \"${UPLOAD_PATH}\", \"mode\": \"${MODE}\", \"autorename\": ${AUTORENAME}, \"mute\": ${MUTE}, \"strict_conflict\": ${STRICT_CONFLICT}${clientModified}}" \
 			--header "Content-Type: application/octet-stream" \
 			--data-binary @"${FILE_PATH}"
 }

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -1,11 +1,13 @@
 Upload() {
 		echo "Uploading '${FILE_PATH}' to '${UPLOAD_PATH}'..."
 
+		# Only include client modified if it's not blank
 		clientModified="";
 		if [ -n "${CLIENT_MODIFIED}" ]; then
 			clientModified=", \"client_modified\": \"${CLIENT_MODIFIED}\"";
 		fi;
 
+		# Convert 0/1 booleans to true/false
 		[[ "${AUTORENAME}" = "1" ]] && AUTORENAME="true" || AUTORENAME="false"
 		[[ "${MUTE}" = "1" ]] && MUTE="true" || MUTE="false"
 		[[ "${STRICT_CONFLICT}" = "1" ]] && STRICT_CONFLICT="true" || STRICT_CONFLICT="false"


### PR DESCRIPTION
Major version bump due to the breaking change of the upload default `mode` previously being `overwrite`, and now being `add` - which now aligns more with the original API.